### PR TITLE
Fix #101: 在 README 中添加 GitHub Codespaces 网页 IDE 链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ opam install . --deps-only
 dune build
 ```
 
+### 在线开发环境
+
+无需本地安装，可以直接在浏览器中体验骆言编程：
+
+[![在 GitHub Codespaces 中打开](https://github.com/codespaces/badge.svg)](https://codespaces.new/UltimatePea/chinese-ocaml)
+
+GitHub Codespaces 提供完整的在线开发环境，包含所有必要的 OCaml 工具和依赖项。
+
 ### 第一个程序
 
 创建文件 `你好.ly`：


### PR DESCRIPTION
在 README 的“快速开始”部分添加了 GitHub Codespaces 在线开发环境链接，用户可以直接在浏览器中体验骆言编程。

## 更改内容
- 添加了“在线开发环境”小节
- 提供了 GitHub Codespaces 徽章和链接
- 解释了在线环境的优势

修复 #101
Fixes #101
Generated with [Claude Code](https://claude.ai/code)